### PR TITLE
Añadir biblioteca interactiva

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -427,3 +427,43 @@ body {
   color: #7f3fbf;
   font-weight: bold;
 }
+
+/* Biblioteca */
+.library-filters {
+  padding: 1rem;
+}
+
+.library-filters select {
+  padding: 0.5rem;
+  font-size: 1rem;
+}
+
+.library-list li {
+  list-style: none;
+  padding: 0.75rem;
+  border-bottom: 1px solid #ddd;
+}
+
+.library-list a {
+  text-decoration: none;
+  color: #7f3fbf;
+}
+
+.library-reader {
+  background: #fff;
+  margin: 1rem;
+  padding: 1rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+}
+
+.reader-controls {
+  margin-top: 1rem;
+  display: flex;
+  justify-content: space-between;
+}
+
+.library-stats {
+  padding: 1rem;
+  text-align: center;
+}

--- a/assets/docs/consejos_juego.txt
+++ b/assets/docs/consejos_juego.txt
@@ -1,0 +1,2 @@
+Estos consejos te ayudarán a mejorar tu rendimiento en las misiones y ganar más experiencia.
+Recuerda siempre trabajar en equipo y consultar a tu maestro.

--- a/assets/docs/guia_arkana.txt
+++ b/assets/docs/guia_arkana.txt
@@ -1,0 +1,2 @@
+Bienvenido a la guía rápida de Arkana.
+Aquí encontrarás los conceptos básicos para empezar tu aventura.

--- a/assets/docs/historia_reino.txt
+++ b/assets/docs/historia_reino.txt
@@ -1,0 +1,2 @@
+La historia del Reino de Arkana está llena de misterios y héroes legendarios.
+Descubre cómo surgieron las grandes casas y sus conflictos.

--- a/assets/js/biblioteca.js
+++ b/assets/js/biblioteca.js
@@ -1,0 +1,94 @@
+// Scripts de la biblioteca
+
+document.addEventListener('DOMContentLoaded', () => {
+  const categorySelect = document.getElementById('category-select');
+  const documentsList = document.getElementById('documents-list');
+  const documentContent = document.getElementById('document-content');
+  const readingTimer = document.getElementById('reading-timer');
+  const markAsReadBtn = document.getElementById('mark-as-read-btn');
+  const readsCount = document.getElementById('reads-count');
+
+  // Documentos de ejemplo
+  const docs = [
+    {
+      title: 'Guía rápida de Arkana',
+      category: 'guias',
+      file: 'assets/docs/guia_arkana.txt'
+    },
+    {
+      title: 'Historia del Reino',
+      category: 'lore',
+      file: 'assets/docs/historia_reino.txt'
+    },
+    {
+      title: 'Consejos de Juego',
+      category: 'tutoriales',
+      file: 'assets/docs/consejos_juego.txt'
+    }
+  ];
+
+  let timerInterval = null;
+  let elapsedSeconds = 0;
+
+  function formatTime(secs) {
+    const m = String(Math.floor(secs / 60)).padStart(2, '0');
+    const s = String(secs % 60).padStart(2, '0');
+    return `${m}:${s}`;
+  }
+
+  function startTimer() {
+    clearInterval(timerInterval);
+    elapsedSeconds = 0;
+    readingTimer.textContent = '00:00';
+    timerInterval = setInterval(() => {
+      elapsedSeconds++;
+      readingTimer.textContent = formatTime(elapsedSeconds);
+    }, 1000);
+  }
+
+  function renderDocuments(filter = 'todas') {
+    documentsList.innerHTML = '';
+    const filteredDocs =
+      filter === 'todas' ? docs : docs.filter(d => d.category === filter);
+
+    filteredDocs.forEach(doc => {
+      const li = document.createElement('li');
+      const link = document.createElement('a');
+      link.href = doc.file;
+      link.textContent = doc.title;
+      link.addEventListener('click', evt => {
+        evt.preventDefault();
+        openDocument(doc);
+      });
+      li.appendChild(link);
+      documentsList.appendChild(li);
+    });
+  }
+
+  function openDocument(doc) {
+    fetch(doc.file)
+      .then(res => res.text())
+      .then(text => {
+        documentContent.textContent = text;
+        markAsReadBtn.disabled = false;
+        startTimer();
+      })
+      .catch(() => {
+        documentContent.textContent = 'No se pudo cargar el documento.';
+      });
+  }
+
+  markAsReadBtn.addEventListener('click', () => {
+    clearInterval(timerInterval);
+    markAsReadBtn.disabled = true;
+    documentContent.textContent = '';
+    readingTimer.textContent = '00:00';
+    readsCount.textContent = parseInt(readsCount.textContent) + 1;
+  });
+
+  categorySelect.addEventListener('change', () => {
+    renderDocuments(categorySelect.value);
+  });
+
+  renderDocuments();
+});


### PR DESCRIPTION
## Resumen
- agregar documentos de ejemplo en `assets/docs`
- implementar script `biblioteca.js` con filtro, lector y contador de lecturas
- incluir estilos para la página de biblioteca

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_685a195b0f2c832b8fc78d607f96f75a